### PR TITLE
Add slug to config

### DIFF
--- a/lib/parsers/0.1.js
+++ b/lib/parsers/0.1.js
@@ -39,6 +39,7 @@ const THEME_PROPERTIES = {
  * @property {string} hover
  * @property {string} alias
  * @property {string} name
+ * @property {string} slug
  */
 
 /**
@@ -54,6 +55,7 @@ const validate0p1 = async (filePath, name) => {
 	);
 
 	validateSchema(fileContents, THEME_PROPERTIES, name);
+	fileContents.slug = name;
 
 	return fileContents;
 };


### PR DESCRIPTION
Allows us to identify a school without parsing `window.origin`

**Meta**:
Merge Type: n/a
Reviews Required: 1