### PR TITLE
✨ Add feedback link support and 2021F links

### DIFF
--- a/lib/parsers/0.1.json
+++ b/lib/parsers/0.1.json
@@ -22,6 +22,12 @@
     "gpa": {
       "type": "boolean"
     },
+    "feedbackLink": {
+      "oneOf": [
+        {"type": "string", "format": "url"},
+        {"type": "null"}
+      ]
+    },
     "theme": {
       "type": "object",
       "required": ["primary", "hover"],

--- a/lib/templates/default-config.yml
+++ b/lib/templates/default-config.yml
@@ -5,6 +5,7 @@ theme:
   hover: '#7e4f67'
   background: 'https://static.gradebook.app/sYbR9JXKTI/generic.jpg'
 gpa: true
+feedbackLink: null
 cutoffs:
   A+:
     defaultValue: 93

--- a/schools/aggie.yml
+++ b/schools/aggie.yml
@@ -5,6 +5,7 @@ theme:
   hover: '#880000'
   background: 'https://static.gradebook.app/sYbR9JXKTI/aggie.jpg'
 gpa: true
+feedbackLink: 'https://docs.google.com/forms/d/e/1FAIpQLSegKY6UHxMZsxqZUnvx5XNnyJjSUVOUOfQnVws9oGN9msNLPw/viewform?usp=pp_url&entry.2135011275=Texas+A%26M&entry.1179673150=No'
 cutoffs:
   A:
     defaultValue: 90

--- a/schools/aggiecorps.yml
+++ b/schools/aggiecorps.yml
@@ -6,6 +6,7 @@ theme:
   background: 'https://static.gradebook.app/sYbR9JXKTI/aggiecorps.jpg'
 gpa: true
 partner: true
+feedbackLink: 'https://docs.google.com/forms/d/e/1FAIpQLSegKY6UHxMZsxqZUnvx5XNnyJjSUVOUOfQnVws9oGN9msNLPw/viewform?usp=pp_url&entry.2135011275=Texas+A%26M&entry.1179673150=Yes'
 cutoffs:
   A:
     defaultValue: 90

--- a/schools/blinn.yml
+++ b/schools/blinn.yml
@@ -5,6 +5,7 @@ theme:
   hover: '#002D72'
   background: 'https://static.gradebook.app/sYbR9JXKTI/blinn.jpg'
 gpa: true
+feedbackLink: 'https://docs.google.com/forms/d/e/1FAIpQLSegKY6UHxMZsxqZUnvx5XNnyJjSUVOUOfQnVws9oGN9msNLPw/viewform?usp=pp_url&entry.2135011275=Blinn'
 cutoffs:
   A:
     defaultValue: 90

--- a/schools/bobcat.yml
+++ b/schools/bobcat.yml
@@ -5,6 +5,7 @@ theme:
   hover: '#8d2024'
   background: 'https://static.gradebook.app/sYbR9JXKTI/bobcat.jpg'
 gpa: true
+feedbackLink: 'https://docs.google.com/forms/d/e/1FAIpQLSegKY6UHxMZsxqZUnvx5XNnyJjSUVOUOfQnVws9oGN9msNLPw/viewform?usp=pp_url&entry.2135011275=Texas+State'
 cutoffs:
   A:
     defaultValue: 90

--- a/schools/comet.yml
+++ b/schools/comet.yml
@@ -5,6 +5,7 @@ theme:
   hover: '#e87500'
   background: 'https://static.gradebook.app/sYbR9JXKTI/comet.jpg'
 gpa: true
+feedbackLink: 'https://docs.google.com/forms/d/e/1FAIpQLSegKY6UHxMZsxqZUnvx5XNnyJjSUVOUOfQnVws9oGN9msNLPw/viewform?usp=pp_url&entry.2135011275=UT+Dallas'
 cutoffs:
   A+:
     qualityPoints: 4

--- a/schools/commodore.yml
+++ b/schools/commodore.yml
@@ -5,6 +5,7 @@ theme:
   hover: '#866d4b'
   background: 'https://static.gradebook.app/sYbR9JXKTI/commodore.jpg'
 gpa: true
+feedbackLink: 'https://docs.google.com/forms/d/e/1FAIpQLSegKY6UHxMZsxqZUnvx5XNnyJjSUVOUOfQnVws9oGN9msNLPw/viewform?usp=pp_url&entry.2135011275=Vanderbilt'
 cutoffs:
   A:
     defaultValue: 93

--- a/schools/cougar.yml
+++ b/schools/cougar.yml
@@ -5,6 +5,7 @@ theme:
   hover: '#960C22'
   background: 'https://static.gradebook.app/sYbR9JXKTI/cougar.jpg'
 gpa: true
+feedbackLink: 'https://docs.google.com/forms/d/e/1FAIpQLSegKY6UHxMZsxqZUnvx5XNnyJjSUVOUOfQnVws9oGN9msNLPw/viewform?usp=pp_url&entry.2135011275=University+of+Houston'
 cutoffs:
   A:
     defaultValue: 93

--- a/schools/gator.yml
+++ b/schools/gator.yml
@@ -5,6 +5,7 @@ theme:
   hover: '#0032fb'
   background: 'https://static.gradebook.app/sYbR9JXKTI/gator.jpg'
 gpa: true
+feedbackLink: 'https://docs.google.com/forms/d/e/1FAIpQLSegKY6UHxMZsxqZUnvx5XNnyJjSUVOUOfQnVws9oGN9msNLPw/viewform?usp=pp_url&entry.2135011275=Florida'
 cutoffs:
   A:
     defaultValue: 90

--- a/schools/longhorn.yml
+++ b/schools/longhorn.yml
@@ -5,6 +5,7 @@ theme:
   hover: '#f06c00'
   background: 'https://static.gradebook.app/sYbR9JXKTI/longhorn.jpg'
 gpa: true
+feedbackLink: 'https://docs.google.com/forms/d/e/1FAIpQLSegKY6UHxMZsxqZUnvx5XNnyJjSUVOUOfQnVws9oGN9msNLPw/viewform?usp=pp_url&entry.2135011275=UT+Austin'
 cutoffs:
   A:
     defaultValue: 93

--- a/schools/raider.yml
+++ b/schools/raider.yml
@@ -5,6 +5,7 @@ theme:
   hover: '#880000'
   background: 'https://static.gradebook.app/sYbR9JXKTI/raider.jpg'
 gpa: true
+feedbackLink: 'https://docs.google.com/forms/d/e/1FAIpQLSegKY6UHxMZsxqZUnvx5XNnyJjSUVOUOfQnVws9oGN9msNLPw/viewform?usp=pp_url&entry.2135011275=Texas+Tech'
 cutoffs:
   A:
     defaultValue: 90

--- a/schools/rebel.yml
+++ b/schools/rebel.yml
@@ -5,6 +5,7 @@ theme:
   hover: '#2e4c8d'
   background: 'https://static.gradebook.app/sYbR9JXKTI/rebel.jpg'
 gpa: true
+feedbackLink: 'https://docs.google.com/forms/d/e/1FAIpQLSegKY6UHxMZsxqZUnvx5XNnyJjSUVOUOfQnVws9oGN9msNLPw/viewform?usp=pp_url&entry.2135011275=Ole+Miss'
 cutoffs:
   A:
     defaultValue: 90

--- a/schools/the.yml
+++ b/schools/the.yml
@@ -5,6 +5,7 @@ theme:
   hover: '#7e4f67'
   background: 'https://static.gradebook.app/sYbR9JXKTI/generic.jpg'
 gpa: true
+feedbackLink: 'https://docs.google.com/forms/d/e/1FAIpQLSegKY6UHxMZsxqZUnvx5XNnyJjSUVOUOfQnVws9oGN9msNLPw/viewform?usp=sf_link'
 cutoffs:
   A+:
     defaultValue: 93

--- a/schools/tiger.yml
+++ b/schools/tiger.yml
@@ -5,6 +5,7 @@ theme:
   hover: '#ff8a38'
   background: 'https://static.gradebook.app/sYbR9JXKTI/tiger.jpg'
 gpa: true
+feedbackLink: 'https://docs.google.com/forms/d/e/1FAIpQLSegKY6UHxMZsxqZUnvx5XNnyJjSUVOUOfQnVws9oGN9msNLPw/viewform?usp=pp_url&entry.2135011275=Clemson'
 cutoffs:
   A:
     defaultValue: 90

--- a/schools/wolfpack.yml
+++ b/schools/wolfpack.yml
@@ -5,6 +5,7 @@ theme:
   hover: '#cc0000'
   background: 'https://static.gradebook.app/sYbR9JXKTI/wolfpack.jpg'
 gpa: true
+feedbackLink: 'https://docs.google.com/forms/d/e/1FAIpQLSegKY6UHxMZsxqZUnvx5XNnyJjSUVOUOfQnVws9oGN9msNLPw/viewform?usp=pp_url&entry.2135011275=NC+State'
 cutoffs:
   A+:
     defaultValue: 97


### PR DESCRIPTION
Adds the `feedbackLink` key. This can be null, or a string, or unset. 

Enabling or disabling feedback forms in Gradebook is now as easy as pushing a commit to school-configuration with links to the form for each school, or a subset of schools. Client and server handle the rest:
- [Server PR](https://github.com/gradebook/server/pull/193) 
- [Client PR](https://github.com/gradebook/client/pull/379)

Meta
1 reviewer
rebase