### PR TITLE
create entitlement for decimal course credits

### DIFF
--- a/lib/parsers/0.1.json
+++ b/lib/parsers/0.1.json
@@ -38,6 +38,9 @@
         },
         "direct-support": {
           "type": "boolean"
+        },
+        "decimal-course-credits": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/schools/the.yml
+++ b/schools/the.yml
@@ -6,6 +6,8 @@ theme:
   background: 'https://static.gradebook.app/sYbR9JXKTI/generic.jpg'
 gpa: true
 feedbackLink: null
+entitlements:
+  decimal-course-credits: true
 cutoffs:
   A+:
     defaultValue: 93


### PR DESCRIPTION
As per user request, only certain schools have partial (decimal) course credits. It should be disabled by default, so we will currently only allow it on `the`.

**Meta**
Reviewers: 1